### PR TITLE
2回目以降のログイン時のトークン未設定を直した

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,14 +7,20 @@ import { API_ENDPOINT, MOCK_BEARER } from 'env'
 import 'reset.css'
 import 'day'
 
-import { auth } from "services/firebase";
-import { useAuthState } from "react-firebase-hooks/auth";
+import { auth, setToken } from 'services/firebase'
+import { useAuthState } from 'react-firebase-hooks/auth'
 
 axios.defaults.baseURL = API_ENDPOINT
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient())
- 
+  const [user, loading, error] = useAuthState(auth)
+  useEffect(() => {
+    console.log(user)
+    if (user) {
+      setToken()
+    }
+  }, [user])
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
2回目以降は勝手にログインされるので_appでuseEffectでuser!=nullのときaxiosのヘッダーを再設定するようにした