### PR TITLE
新規作成できないバグを修正

### DIFF
--- a/src/components/EditArea.tsx
+++ b/src/components/EditArea.tsx
@@ -26,7 +26,7 @@ type EditAreaProps = {
   setDialogOpen: Dispatch<SetStateAction<boolean>>
 }
 const maxId = (vertexList: Vertexes): number => {
-  if (vertexList.length == -1) return 0
+  if (vertexList.length <= 0) return 0
   var max = Number(vertexList[0].id)
   vertexList.forEach((v) => {
     const id = Number(v.id)


### PR DESCRIPTION
まちがってvertex.lengthが0のときの処理を-1のときにしてました